### PR TITLE
Add support for reusable patterns

### DIFF
--- a/php/block.php
+++ b/php/block.php
@@ -1,31 +1,24 @@
 <?php
 
-$ppcSchema = [
-    'single'       => true,
-    'type'         => 'string',
-    'auth_callback' => function () {
-        return current_user_can('edit_css');
-    },
-    'show_in_rest' => [
-        'schema' => [
-            'type'  => 'string',
-            'default' => '',
-        ],
-    ],
-];
+// This works by looking for blocks with the compiled CSS and
+// during the render phase, and inlines the css if found.
+// That keeps the inline styles ONLY loaded on pages that have the block.
+add_filter('pre_render_block', function($pre_render, $parsed_block) {
+    // $pre_render is null by default
+    if (!isset($parsed_block['attrs']['ppcAdditionalCssCompiled'])) return $pre_render;
+    if (empty($parsed_block['attrs']['ppcAdditionalCssCompiled'])) return $pre_render;
 
-register_meta('post', 'ppc_additional_css_block_compiled', $ppcSchema);
+    $ppc_additional_css = $parsed_block['attrs']['ppcAdditionalCssCompiled'];
+    $ppc_block_id = $parsed_block['attrs']['ppcClassId'];
 
-add_action(
-    'wp_enqueue_scripts',
-    function () {
-        $ppc_additional_css = get_post_meta(get_the_ID(), 'ppc_additional_css_block_compiled', true);
-        if (empty($ppc_additional_css)) {
-            return;
-        }
-        wp_register_style('ppc-inline-styles-block', false, [], 123);
-        wp_enqueue_style('ppc-inline-styles-block');
-        // See: https://github.com/WordPress/WordPress/blob/master/wp-includes/theme.php#L1880-L1893
-        wp_add_inline_style('ppc-inline-styles-block', wp_strip_all_tags($ppc_additional_css));
-    }
-);
+    // Should this error if the css is found but not the id?
+    if (empty($ppc_block_id) || empty($ppc_additional_css)) return $pre_render;
+
+    wp_register_style("ppc-block-{$ppc_block_id}", false, [], null);
+    wp_enqueue_style("ppc-block-{$ppc_block_id}");
+
+    // WP style of safe echoing inline styles
+    // See: https://github.com/WordPress/WordPress/blob/9ecfdd8e5a42ed4b66ffecb88321242717c89831/wp-includes/theme.php#L1920
+    wp_add_inline_style("ppc-block-{$ppc_block_id}", wp_strip_all_tags($ppc_additional_css));
+    return $pre_render;
+}, 10, 2);

--- a/php/post.php
+++ b/php/post.php
@@ -6,6 +6,7 @@ $ppcSchema = [
     'auth_callback' => function () {
         return current_user_can('edit_css');
     },
+    'sanitize_callback' => 'sanitize_textarea_field',
     'show_in_rest' => [
         'schema' => [
             'type'  => 'string',

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Per Page CSS ===
 Contributors:      kbat82
-Tags:              css, styles, stylesheet, inline styles, custom css
+Tags:              pattern, css, styles, stylesheet, inline styles, custom css
 Tested up to:      6.2
 Stable tag:        0.1.0
 License:           GPL-2.0-or-later
@@ -78,6 +78,11 @@ becomes:
 1. An example showing the live updates.
 
 == Changelog ==
+
+- Feature: Now supports reusable blocks/patterns
+- Improvement: Removed the public className attribute requirement from the Additional Settings area
+- Improvement: Instead of saving as meta on a post, it now pulls from the attribute directly during page load (via the pre_render_block filter).
+- Fix: Now it will only show on post types with the public setting set to true
 
 = 0.1.0 - 2022-01-22
 * Initial release

--- a/src/components/BlockControl.tsx
+++ b/src/components/BlockControl.tsx
@@ -108,20 +108,13 @@ export const BlockControl = (
         setAttributes({
             ppcAdditionalCss: css,
             ppcClassId,
-            className: [
-                ...new Set([...(existingClassNames ?? []), ppcClassId]),
-            ].join(' '),
         });
-    }, [css, setAttributes, ready, ppcClassId, existingClassNames]);
+    }, [css, setAttributes, ready, ppcClassId]);
 
     useEffect(() => {
         if (!ready) return;
         if (compiled === compiledCss) return;
         setAttributes({ ppcAdditionalCssCompiled: compiled });
-        // This will trigger to save all the custom styles to the database
-        window.dispatchEvent(
-            new CustomEvent('kevinbatdorf::ppc-editing-block'),
-        );
     }, [compiled, setAttributes, ready, compiledCss]);
 
     useLayoutEffect(() => {

--- a/src/components/PageControl.tsx
+++ b/src/components/PageControl.tsx
@@ -20,6 +20,20 @@ import { CodePreview } from './CodePreview';
 export const PageControl = () => {
     const [ready, setReady] = useState(false);
     const [warnings, setWarnings] = useState<CssWarning[]>([]);
+
+    // Only show on public post types
+    const isPublicPostType = useSelect((select) => {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore-next-line - not typed in core
+        const { getEditedPostAttribute } = select(editorStore);
+        const postType = getEditedPostAttribute('type');
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore-next-line - not typed in core
+        const { getPostType } = select(coreStore);
+        const { viewable } = getPostType?.(postType) || {};
+        return viewable ?? false;
+    }, []);
+
     const { initialCss, compiledCss } = useSelect((select) => {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore-next-line - TODO
@@ -62,9 +76,9 @@ export const PageControl = () => {
     }, []);
 
     useEffect(() => {
-        if (!hasPermission) return;
+        if (!hasPermission || !isPublicPostType) return;
         init().then(() => setReady(true));
-    }, [hasPermission]);
+    }, [hasPermission, isPublicPostType]);
 
     useEffect(() => {
         if (!ready || !initialCss) return;
@@ -126,6 +140,8 @@ export const PageControl = () => {
             },
         });
     }, [compiled, editPost, ready]);
+
+    if (!ready) return null;
 
     return (
         <PluginDocumentSettingPanel


### PR DESCRIPTION
This PR adds support for reusable patterns, making this a very useful tool for reusability. You can now set a style on reusable pattern and it will reflect anywhere that pattern is loaded.

Closes https://github.com/KevinBatdorf/per-page-css/issues/24