### PR TITLE
Add selector update

### DIFF
--- a/php/post.php
+++ b/php/post.php
@@ -27,7 +27,8 @@ add_action(
         }
         wp_register_style('ppc-inline-styles-post', false, [], 123);
         wp_enqueue_style('ppc-inline-styles-post');
-        // See: https://github.com/WordPress/WordPress/blob/master/wp-includes/theme.php#L1880-L1893
+        // WP style of safe echoing inline styles
+        // See: https://github.com/WordPress/WordPress/blob/9ecfdd8e5a42ed4b66ffecb88321242717c89831/wp-includes/theme.php#L1920
         wp_add_inline_style('ppc-inline-styles-post', wp_strip_all_tags($ppc_additional_css));
     }
 );

--- a/readme.txt
+++ b/readme.txt
@@ -13,20 +13,13 @@ Lightening Fast, Safe, In-editor CSS Optimization and Minification Tool.
 Add CSS styles to any page and have it load only on that page. Unlike with similar tools, your css will be optimized, minified, and inlined directly into the head of the page.
 
 = Features =
-- It's fast. Likely faster than your development build tool.
+- It's fast. Likely faster than your development build tool
+- Scopes styles to the block, removing the need to manage class naming
+- Supports reusable patterns
 - See changes on the page as you make them
 - Auto adds vendor prefixes as needed (removes redundant ones too)
 - Combines adjacent rules (to decrease size)
 - Minifies colors and math functions to simplify according to spec
-- Works on blocks too, and scopes the styles to the block
-
-= More features coming =
-- Block theme directive helpers
-- Add CSS per template, or site-wide
-- Pattern matching to load dynamically
-- Larger editor
-- Snippet manager
-- PostCSS-like helpers
 
 = More Info =
 - Follow [@kevinbatdorf](https://twitter.com/kevinbatdorf) on Twitter
@@ -80,6 +73,8 @@ becomes:
 == Changelog ==
 
 - Feature: Now supports reusable blocks/patterns
+- Improvement: Added the option to update the CSS selector used for scoping (useful for duplicating blocks)
+- Improvement: Added some examples when no CSS is present
 - Improvement: Removed the public className attribute requirement from the Additional Settings area
 - Improvement: Instead of saving as meta on a post, it now pulls from the attribute directly during page load (via the pre_render_block filter).
 - Fix: Now it will only show on post types with the public setting set to true

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,6 @@ addFilter(
                 ...settings.attributes,
                 ppcAdditionalCss: {
                     type: 'string',
-                    default: '',
                 },
                 ppcAdditionalCssCompiled: {
                     type: 'string',


### PR DESCRIPTION
This adds a way for users to update the class ID in the case they duplicate a block, or in the rare case of an id generation clash

![Screen Shot 2023-07-10 at 10 59 46 AM](https://github.com/KevinBatdorf/per-page-css/assets/1478421/799df138-3e2f-4d93-adec-0b642e87363d)

Also adds some example use:

![Screen Shot 2023-07-10 at 10 59 37 AM](https://github.com/KevinBatdorf/per-page-css/assets/1478421/d8df315d-9761-4299-98a2-1d6cb23db117)
